### PR TITLE
Fix the asterisk key name

### DIFF
--- a/grandjean_layout.json
+++ b/grandjean_layout.json
@@ -35,7 +35,7 @@
 			"color_pressed": "#bbe3f2"
         },
 		{
-            "name": "*-",
+            "name": "*",
             "label": "*",
             "x": 3,
             "y": 0,


### PR DESCRIPTION
The `*` key is not being shown as being pressed when using this layout with the plover-grandjean plugin.
According to https://github.com/stenomax/plover_grandjean/blob/173f2b6375f507a902affb9dc1b6c942ba825611/plover_grandjean/system.py#L4, the name for the asterisk key is `*`, not `*-`.